### PR TITLE
updated package.json to specify 'main' and 'exports:./*'

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
         ".": {
             "types": "./dist/index.d.ts",
             "svelte": "./dist/index.js"
-        }
+        },
+		"./*": "./dist/*"
     },
 	"files": ["dist"],
+	"main": "dist/index.js",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "svelte-kit sync && svelte-package && sass dist/css:dist/css",


### PR DESCRIPTION
This change was necessary in order to get `npx vite build` to resolve the lines from the README.md:
```
  import { SubmitForm } from '@restspace/svelte-schema-form';
  import '@restspace/svelte-schema-form/css/layout.scss';
  import '@restspace/svelte-schema-form/css/basic-skin.scss';
```

If there was another setup step that was required so that these package.json changes wouldn't have been needed in the module, that step should be documented in the README.