### PR TITLE
Fix ipv4 format

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
         ".": {
             "types": "./dist/index.d.ts",
             "svelte": "./dist/index.js"
-        }
+        },
+		"./*": "./dist/*"
     },
 	"files": ["dist"],
+	"main": "dist/index.js",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "svelte-kit sync && svelte-package && sass dist/css:dist/css",

--- a/src/lib/SchemaForm.svelte
+++ b/src/lib/SchemaForm.svelte
@@ -68,6 +68,7 @@
 			time: String,
 			"date-time": String,
 			date: String,
+			"string-ipv4": String,
 			number: Number,
 			integer: Number,
 			boolean: Boolean,

--- a/src/lib/errorMapper.ts
+++ b/src/lib/errorMapper.ts
@@ -1,11 +1,11 @@
-import { get } from "@exodus/schemasafe/src/pointer";
 import { jsonPointerToPath } from "./types/schema";
 import { afterLast } from "./utilities.js";
 
 export function errorMapper(schema: any, value: any, keywordLocation: string, instanceLocation: string): [ string, string ] {
 	const location = jsonPointerToPath(instanceLocation);
 	const keyword = afterLast(keywordLocation, '/');
-	const keyValue = jsonPointerToPath(keywordLocation);
+	const fullKeyPath = jsonPointerToPath(keywordLocation);
+	const keyValue = fullKeyPath.split('.').reduce((sub, key) => sub[key], schema);
 	switch (keyword) {
 		case "required":
 			return [ location, 'Please enter a value for this item' ];
@@ -18,15 +18,16 @@ export function errorMapper(schema: any, value: any, keywordLocation: string, in
 		case "maxLength":
 			return [ location, `Please enter text no longer than ${keyValue} characters` ];
 		case "pattern":
-			return [ location, `Please enter properly formatted value` ];
+			return [ location, `Please enter properly formatted value: ${keyValue}` ];
 		case "format":
 			const valMap = {
 				"date-time": "date and time",
 				time: "time",
 				date: "date",
 				email: "email address",
+				ipv4: "IPv4 address",
 			} as Record<string, string>;
-			return [ location, `Please enter a properly formatted ${valMap[keyValue]}` ];
+			return [ location, `Please enter a properly formatted ${valMap[keyValue] || keyValue}` ];
 	}
 	return [ location, `Fails to satisfy schema at ${jsonPointerToPath(keywordLocation)}` ];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,12 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
-		"strict": true
-	}
+		"strict": true,
+		"outDir": "dist",
+		"ignoreDeprecations": "5.0",
+		"verbatimModuleSyntax": true
+	},
+	"exclude": [
+		"dist"
+	]
 }


### PR DESCRIPTION
This corrects the `errorMapper` to produce the correct strings and also enables support for IPv4 string format.

Realistically, the component map in `SchemaForm` should probably just default all unknown things to `String` so that there's not a large duplication of the effort already undertaken by the validator module.